### PR TITLE
Fix get__hashmap() array error on hash type 0

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -235,6 +235,7 @@ void *get__hashmap(hashmap *hash__m, void *key) {
 					returnMeat->payload = ll_search->ll_meat;
 					returnMeat->payload__length = ll_search->arrIndex + 1;
 				} else { // define array
+					ll_search->isArray = 1;
 					void *ll_tempMeatStorage = ll_search->ll_meat;
 
 					ll_search->max__arrLength = 2;


### PR DESCRIPTION
There was a major issue withing the `get__hashmap` function where if the param type `0` was used for the hashmap and something wasn't an array yet, the new pointer created for the array was not saved anywhere. This request creates the update to change the boolean value to ensure that the next time `get__hashmape` is called the updated array is used.