### PR TITLE
Fixing Overload Insert Function

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -549,7 +549,7 @@ int insert__hashmap(hashmap *hash__m, void *key, void *value, ...) {
 		inserter.compareKey = compareIntKey;
 		inserter.destroyKey = NULL;
 	} else {
-		inserter.printKey = firstArgumentCheck;
+		inserter.printKey = va_arg(ap, void (*)(void *));
 		// do the same for compareKey 
 		inserter.compareKey = va_arg(ap, int (*)(void *, void *));
 


### PR DESCRIPTION
A small error in how the overload worked for special cases. This updates allows for the use of the `print_key` functionality when not using the default behavior. An insert function would look like:

```C
insert(hashmap *map, char *key, void *value, "", printCharKey, compareCharKey, destroyCharKey);
```

The use of the `""` makes it possible to then also add the `printCharKey`, which was previously an error.