### PR TITLE
fix issue in ll_destroy

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -251,6 +251,8 @@ int delete__hashmap(hashmap *hash__m, void *key) {
 		// extract parent from the hashmap:
 		hash__m->map[mapPos] = ll_search;
 
+		// ensure entire cut from current ll:
+		ll_parent->next = NULL;
 		ll_destroy(ll_parent, hash__m->destroy);
 
 		return 0;
@@ -264,6 +266,7 @@ int delete__hashmap(hashmap *hash__m, void *key) {
 			// extract the key from the linked list
 			ll_parent->next = ll_next(ll_search);
 
+			ll_search->next = NULL;
 			ll_destroy(ll_search, hash__m->destroy);
 
 			return 0;


### PR DESCRIPTION
There was a small error with `delete__hashmap` related to not entirely extracting the value before deletion, which resulted in sometimes deleting (as with a linked list) the entirety of the values below it. This pull request fixes that issue by ensuring the value to-be-delete is fully extracted pre-deletion.