### PR TITLE
fix on get__hashmap array feature

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -244,7 +244,7 @@ void *get__hashmap(hashmap *hash__m, void *key) {
 					ll_search->ll_meat = malloc(sizeof(void *) * ll_search->max__arrLength * 2);
 					((void **) ll_search->ll_meat)[0] = ll_tempMeatStorage;
 
-					returnMeat->payload = ll_search->ll_meat;
+					returnMeat->payload = ll_tempMeatStorage;
 					returnMeat->payload__length = ll_search->arrIndex + 1;
 				}
 


### PR DESCRIPTION
This feature fixes a small bug on returning hashmap arrays. Previously, if there was one value, the `get__hashmap()` function tried to build a array while still sending the one payload. However, there was an error in accessing that value, which has now been fixed. No other code was changed for this.